### PR TITLE
アプリ異常終了バグの修正

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+CardShuffle

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -49,7 +49,7 @@
       <item index="0" class="java.lang.String" itemvalue="org.mockito.Mock" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
         applicationId "net.wackwack.pic_card_memory"
         minSdk 23
         targetSdk 33
-        versionCode 6
+        versionCode 7
         versionName "${majorVersion}.${minorVersion}.${patchVersion}"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         archivesBaseName = "app-${defaultConfig.versionName}"

--- a/app/src/main/java/net/wackwack/pic_card_memory/game/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/net/wackwack/pic_card_memory/game/viewmodel/GameViewModel.kt
@@ -36,7 +36,7 @@ class GameViewModel @Inject  constructor(
     val imageCards: List<ImageCard>
         get() = _imageCards
     private val _cardOperationMutex  = Mutex()
-    private val _message = MutableSharedFlow<GameMessage>(replay = 1)
+    private val _message = MutableSharedFlow<GameMessage>(replay = 0)
     val message: SharedFlow<GameMessage> = _message
     private val _elapsedTime = MutableStateFlow<Long>(0)
     val elapsedTime: StateFlow<Long> = _elapsedTime
@@ -45,9 +45,9 @@ class GameViewModel @Inject  constructor(
         get() = _players.value[0].name
     val player2Name: String
         get() = _players.value[1].name
-    private val _player1Score = MutableStateFlow<Int>(0)
+    private val _player1Score = MutableStateFlow(0)
     val player1Score: StateFlow<Int> = _player1Score.asStateFlow()
-    private val _player2Score = MutableStateFlow<Int>(0)
+    private val _player2Score = MutableStateFlow(0)
     val player2Score: StateFlow<Int> = _player2Score.asStateFlow()
     private val _currentPlayerIndex = MutableStateFlow(0)
     val currentPlayerIndex: StateFlow<Int> = _currentPlayerIndex
@@ -90,6 +90,7 @@ class GameViewModel @Inject  constructor(
                             }
                         )
                     }
+                    Log.d(javaClass.simpleName, "Emitted: Start Game")
                     _message.emit(GameMessage.Start)
                 }
             } catch(e: InsufficientImagesException) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,15 @@ buildscript {
     ext.hlt_version= '2.46.1'
     dependencies {
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hlt_version"
-        classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'com.google.gms:google-services:4.4.0'
     }
 }
 plugins {
-    id 'com.android.application' version '8.0.1' apply false
-    id 'com.android.library' version '8.0.1' apply false
+    id 'com.android.application' version '8.1.1' apply false
+    id 'com.android.library' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
- #14 
  - アニメーションの処理が実行されてしまうことが原因のため、こルーチンスコープをviewLifeCycleOwnerスコープに移動した上で、アニメーション処理内でviewLifeCycleOwner取得時の例外処理を行う。
- #15 
  - GameViewModel内のSharedFlowのReplayを0に設定
